### PR TITLE
Use integer with limit of 8 bytes instead of bigint in Passkeys generator

### DIFF
--- a/lib/generators/devise/webauthn/passkey_model/passkey_model_generator.rb
+++ b/lib/generators/devise/webauthn/passkey_model/passkey_model_generator.rb
@@ -18,7 +18,7 @@ module Devise
           "external_id:string:uniq",
           "name:string",
           "public_key:text",
-          "sign_count:bigint",
+          "sign_count:integer{8}",
           "#{user_model_name}:references"
         ]
       end


### PR DESCRIPTION
Using `bigint` raised this error:
```
Could not generate field 'sign_count' with unknown type 'bigint'.
```

`integer{8}` generates:
```
t.integer "sign_count", limit: 8
```

The sign count should be a 32-bit unsigned big-endian integer, so 8 bytes should be enough.