### PR TITLE
Load `engine.rake` in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
+load "rails/tasks/engine.rake"
+
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec


### PR DESCRIPTION
This allows us to run commands like `rails db:migrate` standing at the root directory without having to cd to the dummy app dir.

### References:
- [engine.rake](https://github.com/rails/rails/blob/1a40ef61e3c8abde8cb3bc0aaf0aa3222bb179be/railties/lib/rails/tasks/engine.rake)
- [Engine Rakefile template](https://github.com/rails/rails/blob/1a40ef61e3c8abde8cb3bc0aaf0aa3222bb179be/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt#L4-L5)