### PR TITLE
Allow to generate passkeys view

### DIFF
--- a/lib/generators/devise/webauthn/views_generator.rb
+++ b/lib/generators/devise/webauthn/views_generator.rb
@@ -12,9 +12,18 @@ module Devise
       argument :scope, required: false, default: nil,
                        desc: "The scope to copy views to"
 
+      class_option :views, aliases: "-v", type: :array,
+                           desc: "Select specific view directories to generate (sessions, passkeys)"
+
       def copy_views
-        view_directory :passkeys
-        view_directory :sessions
+        if options[:views]
+          options[:views].each do |directory|
+            view_directory directory.to_sym
+          end
+        else
+          view_directory :passkeys
+          view_directory :sessions
+        end
       end
 
       private

--- a/spec/generators/devise/webauthn/views_generator_spec.rb
+++ b/spec/generators/devise/webauthn/views_generator_spec.rb
@@ -29,4 +29,13 @@ RSpec.describe Devise::Webauthn::ViewsGenerator, type: :generator do
       assert_file "app/views/admins/passkeys/new.html.erb"
     end
   end
+
+  context "when passing views option" do
+    let(:generator_instance) { generator([], ["-v", "passkeys"]) }
+
+    it "copies only the specified views" do
+      assert_file "app/views/devise/passkeys/new.html.erb"
+      assert_no_file "app/views/devise/sessions/new.html.erb"
+    end
+  end
 end


### PR DESCRIPTION
- Allow to generate passkeys views
- Allow to choose what views to generate, for example:

To generate all views:
```
rails generate devise:webauthn:views
```

To generate only sessions views:
```
rails generate devise:webauthn:views -v sessions
```
etc.