### PR TITLE
Fix psych version to 4.X in Rails 7.1 gemfile

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -18,6 +18,7 @@ appraise "rails-7_1" do
   gem "capybara", "~> 3.39"
   gem "importmap-rails", "~> 2.0"
   gem "pry-byebug", "~> 3.10"
+  gem "psych", "~> 4.0"
   gem "rack", "~> 2.2"
   gem "rspec-rails", "~> 7.1"
   gem "sqlite3", "~> 1.7"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -17,6 +17,7 @@ gem "rubocop-rspec", "~> 3.6"
 gem "selenium-webdriver"
 gem "sqlite3", "~> 1.7"
 gem "stimulus-rails", "~> 1.3"
+gem "psych", "~> 4.0"
 gem "rack", "~> 2.2"
 
 gemspec path: "../"


### PR DESCRIPTION
As of now it is intermitently causing issues during bundle installs:
```
/opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:456:in
`parse_stream': undefined method `parse' for #<Psych::Parser:0x0000557c62c2c520>
(NoMethodError)
	from /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:390:in `parse'
	from /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:277:in `load'
from /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:578:in `block
in load_file'
	from /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:577:in `open'
from /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:577:in
`load_file'
	from extconf.rb:162:in `mini_portile_config'
	from extconf.rb:157:in `sqlite3_config'
	from extconf.rb:141:in `minimal_recipe'
	from extconf.rb:51:in `configure_packaged_libraries'
	from extconf.rb:17:in `configure'
	from extconf.rb:285:in `<main>'
```