### PR TITLE
Fix Devise not generating url helpers for `passkey_authenticatable` module

### DIFF
--- a/lib/devise/webauthn/engine.rb
+++ b/lib/devise/webauthn/engine.rb
@@ -15,7 +15,7 @@ module Devise
           {
             model: "devise/models/passkey_authenticatable",
             strategy: true,
-            route: { passkey_authentication: routes }
+            route: { passkeys: [nil, :new, :create, :destroy] }
           }
         )
       end

--- a/lib/devise/webauthn/helpers/credentials_helper.rb
+++ b/lib/devise/webauthn/helpers/credentials_helper.rb
@@ -5,7 +5,7 @@ module Devise
     module CredentialsHelper
       def create_passkey_form(form_classes: nil, &block)
         form_with(
-          url: passkeys_path,
+          url: passkeys_path(resource_name),
           method: :post,
           class: form_classes,
           data: {
@@ -75,10 +75,6 @@ module Devise
 
       def resource_session_path
         session_path(resource_name)
-      end
-
-      def passkeys_path
-        main_app.public_send("#{resource_name}_passkeys_path")
       end
     end
   end

--- a/lib/devise/webauthn/routes.rb
+++ b/lib/devise/webauthn/routes.rb
@@ -5,7 +5,7 @@ module ActionDispatch
     class Mapper
       protected
 
-      def devise_passkey_authentication(_mapping, controllers)
+      def devise_passkeys(_mapping, controllers)
         resources :passkeys, only: %i[new create destroy], controller: controllers[:passkeys]
       end
     end


### PR DESCRIPTION
When we are registering the `passkey_authenticatable` module, we were sending the [engine's `routes`](https://github.com/rails/rails/blob/5cffb7c/railties/lib/rails/engine.rb#L542-L548) method as the routes of the module:

https://github.com/cedarcode/devise-webauthn/blob/8769b214da43ab5b3a4aadd61319a1e0272d00df/lib/devise/webauthn/engine.rb#L18

Which causes `Devise::URL_HELPERS` to return the following:

```
(ruby) Devise::URL_HELPERS
{session: [nil, :new, :destroy],
 omniauth_callback: [],
 password: [nil, :new, :edit],
 registration: [nil, :new, :edit, :cancel],
 confirmation: [nil, :new],
 unlock: [nil, :new],
 passkey_authentication: [#<Rails::Engine::LazyRouteSet:0x0000000126a896a8>]}
 ```
 
This is incorrect, and makes it so that `Devise` doesn't generate the url helpers for the module, as it does for the other modules (like `session_path(resource_name)`) for instance.
 
https://github.com/heartcombo/devise/blob/b76d18d27783ad2079e1e75773ef9d1e30005fdd/lib/devise/controllers/url_helpers.rb#L37-L58

We should instead follow a similar approach to the one that the Devise's modules use:

https://github.com/heartcombo/devise/blob/f39c6fd/lib/devise/modules.rb#L8-L9

I also had to change the route mapper as with `devise_passkey_authentication`, the generated url helper ended up being `passkey_authentication_path(resource_name)` which looks for the (if `user` is the `resource`, for instance) `user_passkey_authentication_path` which raises an error as we are defining the routes as simply `passkeys`. Therefore, I changed the route mapper to `devise_passkeys` so the generated url helper is `passkeys_path(resource_name)` which looks for the correct route.