### PR TITLE
Generate url helpers for `passkey_authenticatable` module

### DIFF
--- a/app/controllers/devise/passkeys_controller.rb
+++ b/app/controllers/devise/passkeys_controller.rb
@@ -51,7 +51,7 @@ module Devise
     # The default url to be used after creating a passkey. You can overwrite
     # this method in your own PasskeysController.
     def after_update_path
-      public_send("new_#{resource_name}_passkey_path")
+      new_passkey_path(resource_name)
     end
   end
 end

--- a/lib/devise/webauthn.rb
+++ b/lib/devise/webauthn.rb
@@ -9,6 +9,7 @@ require_relative "models/passkey_authenticatable"
 require_relative "strategies/passkey_authenticatable"
 require_relative "webauthn/helpers/credentials_helper"
 require_relative "webauthn/routes"
+require_relative "webauthn/url_helpers"
 
 module Devise
   module Webauthn

--- a/lib/devise/webauthn/engine.rb
+++ b/lib/devise/webauthn/engine.rb
@@ -15,7 +15,7 @@ module Devise
           {
             model: "devise/models/passkey_authenticatable",
             strategy: true,
-            route: { passkey_authentication: routes }
+            route: { passkey_authentication: [] }
           }
         )
       end
@@ -24,6 +24,10 @@ module Devise
         ActiveSupport.on_load(:action_view) do
           include Devise::Webauthn::CredentialsHelper
         end
+      end
+
+      initializer "devise.webauthn.url_helpers" do
+        Devise.include_helpers(Devise::Webauthn)
       end
     end
   end

--- a/lib/devise/webauthn/helpers/credentials_helper.rb
+++ b/lib/devise/webauthn/helpers/credentials_helper.rb
@@ -5,7 +5,7 @@ module Devise
     module CredentialsHelper
       def create_passkey_form(form_classes: nil, &block)
         form_with(
-          url: passkeys_path,
+          url: passkeys_path(resource_name),
           method: :post,
           class: form_classes,
           data: {
@@ -75,10 +75,6 @@ module Devise
 
       def resource_session_path
         session_path(resource_name)
-      end
-
-      def passkeys_path
-        main_app.public_send("#{resource_name}_passkeys_path")
       end
     end
   end

--- a/lib/devise/webauthn/url_helpers.rb
+++ b/lib/devise/webauthn/url_helpers.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Devise
+  module Webauthn
+    # Create url helpers to be used with resource/scope configuration. Acts as
+    # proxies to the generated routes created by devise.
+    # Resource param can be a string or symbol, a class, or an instance object.
+    # Example using a :user resource:
+    #
+    #   new_passkey_path(:user)      => new_user_passkey_path
+    #   passkeys_path(:user)         => user_passkeys_path
+    #   passkey_path(:user)          => user_passkey_path
+    #
+    # Those helpers are included by default to ActionController::Base.
+    #
+    # In case you want to add such helpers to another class, you can do
+    # that as long as this new class includes both url_helpers and
+    # mounted_helpers. Example:
+    #
+    #     include Rails.application.routes.url_helpers
+    #     include Rails.application.routes.mounted_helpers
+    #
+    module UrlHelpers
+      {
+        passkeys: [nil],
+        passkey: [nil, :new]
+      }.each do |route, actions|
+        %i[path url].each do |path_or_url|
+          actions.each do |action|
+            action = action ? "#{action}_" : ""
+            method = :"#{action}#{route}_#{path_or_url}"
+
+            define_method method do |resource_or_scope, *args|
+              scope = Devise::Mapping.find_scope!(resource_or_scope)
+              router_name = Devise.mappings[scope].router_name
+              context = router_name ? send(router_name) : _devise_route_context
+              context.send("#{action}#{scope}_#{route}_#{path_or_url}", *args)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

When we are registering the `passkey_authenticatable` module, we were sending the [engine's `routes`](https://github.com/rails/rails/blob/5cffb7c/railties/lib/rails/engine.rb#L542-L548) method as the routes of the module:

https://github.com/cedarcode/devise-webauthn/blob/8769b214da43ab5b3a4aadd61319a1e0272d00df/lib/devise/webauthn/engine.rb#L18

Which causes `Devise::URL_HELPERS` to return the following:

```
(ruby) Devise::URL_HELPERS
{session: [nil, :new, :destroy],
 omniauth_callback: [],
 password: [nil, :new, :edit],
 registration: [nil, :new, :edit, :cancel],
 confirmation: [nil, :new],
 unlock: [nil, :new],
 passkey_authentication: [#<Rails::Engine::LazyRouteSet:0x0000000126a896a8>]}
 ```
 
This is incorrect, and makes it so that `Devise` doesn't generate the url helpers for the module, as it does for the other modules (like `session_path(resource_name)`) for instance.
 
https://github.com/heartcombo/devise/blob/b76d18d27783ad2079e1e75773ef9d1e30005fdd/lib/devise/controllers/url_helpers.rb#L37-L58

We tried instead follow a similar approach to the one that the Devise's modules use:

https://github.com/heartcombo/devise/blob/f39c6fd/lib/devise/modules.rb#L8-L9

but [couldn't make it work](https://github.com/cedarcode/devise-webauthn/pull/38).

## Details

This PR then adds a new `UrlHelpers` module that will generate the helpers for our `passkey_authenticatable` module. It follows the same approach as Devise's url generator but allowing us to create url helpers that follow Rails' conventions for plural resources.

This is a similar approach to the one took by `Devise`'s `Omniauth` module:

https://github.com/heartcombo/devise/blob/b76d18d27783ad2079e1e75773ef9d1e30005fdd/lib/devise/omniauth/url_helpers.rb