### PR TITLE
Prevent passkey_authenticatable strategy from being always added

### DIFF
--- a/lib/devise/models/passkey_authenticatable.rb
+++ b/lib/devise/models/passkey_authenticatable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
+require "devise/strategies/passkey_authenticatable"
 
 module Devise
   module Models

--- a/lib/devise/strategies/passkey_authenticatable.rb
+++ b/lib/devise/strategies/passkey_authenticatable.rb
@@ -41,3 +41,5 @@ module Devise
     end
   end
 end
+
+Warden::Strategies.add(:passkey_authenticatable, Devise::Strategies::PasskeyAuthenticatable)

--- a/lib/devise/webauthn.rb
+++ b/lib/devise/webauthn.rb
@@ -5,8 +5,6 @@ require "webauthn"
 
 require_relative "webauthn/version"
 require_relative "webauthn/engine"
-require_relative "models/passkey_authenticatable"
-require_relative "strategies/passkey_authenticatable"
 require_relative "webauthn/helpers/credentials_helper"
 require_relative "webauthn/routes"
 

--- a/lib/devise/webauthn/engine.rb
+++ b/lib/devise/webauthn/engine.rb
@@ -5,10 +5,6 @@ module Devise
     class Engine < ::Rails::Engine
       isolate_namespace Devise::Webauthn
 
-      initializer "devise.webauthn.setup" do
-        Warden::Strategies.add(:passkey_authenticatable, Devise::Strategies::PasskeyAuthenticatable)
-      end
-
       initializer "devise.webauthn.add_module" do
         Devise.add_module(
           :passkey_authenticatable,


### PR DESCRIPTION
1. Remove
```ruby
Warden::Strategies.add(:passkey_authenticatable, Devise::Strategies::PasskeyAuthenticatable)
```
from being executed during initialization. 
Move that line to the strategy file.

2. Remove
```ruby
require_relative "models/passkey_authenticatable"
require_relative "strategies/passkey_authenticatable"
```
from `devise/webauthn.rb` to prevent the model and strategy from being always loaded.

3.  Add
```ruby
require "devise/strategies/passkey_authenticatable"
``` 
to the `passkey_authenticatable` model. 


With these changes, `Warden::Strategies.add` will only be called when the strategy file gets loaded -> when the model gets loaded -> when the module is passed to the [devise method](https://github.com/heartcombo/devise/blob/c6b08ae7e12d068e7fde62dda951316147300daf/lib/devise/models.rb#L79)