### PR TITLE
Avoid testing against Rails edge using Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,9 @@ jobs:
           - rails_7_1
 
         exclude:
+          - ruby: 3.2
+            gemfile: rails_edge
+
           - ruby: 3.1
             gemfile: rails_edge
           - ruby: 3.1


### PR DESCRIPTION
We are getting the following error in the CI:

```
Fetching https://github.com/rails/rails
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Could not find compatible versions

Because every version of rails depends on Ruby >= 3.3.0
  and rails_edge.gemfile depends on rails >= 0,
  Ruby >= 3.3.0 is required.
So, because current Ruby version is = 3.2.9,
  version solving has failed.
```

Removal of Ruby 3.2 support was merged a couple of days ago to Rails:

https://github.com/rails/rails/commit/fc22a8fc62d5240c0d09f1078800900ea2f132ff