### PR TITLE
Submit WebAuthn forms with `requestSubmit` so Turbo can intercept

### DIFF
--- a/app/assets/javascript/devise/webauthn.js
+++ b/app/assets/javascript/devise/webauthn.js
@@ -19,6 +19,8 @@ export class WebauthnCreateElement extends HTMLElement {
     }
 
     this.closest('form').addEventListener('submit', async (event) => {
+      if (this.dataset.ceremonyCompleted) return;
+
       event.preventDefault();
 
       try {
@@ -28,8 +30,10 @@ export class WebauthnCreateElement extends HTMLElement {
 
         this.querySelector('[data-webauthn-target="response"]').value = await this.stringifyRegistrationCredentialWithGracefullyHandlingAuthenticatorIssues(credential);
 
-        this.closest('form').submit();
+        this.dataset.ceremonyCompleted = "true";
+        this.closest('form').requestSubmit();
       } catch (error) {
+        delete this.dataset.ceremonyCompleted;
         this.handleError(error);
       }
     });
@@ -100,6 +104,8 @@ export class WebauthnGetElement extends HTMLElement {
     }
 
     this.closest('form').addEventListener('submit', async (event) => {
+      if (this.dataset.ceremonyCompleted) return;
+
       event.preventDefault();
 
       try {
@@ -109,8 +115,10 @@ export class WebauthnGetElement extends HTMLElement {
 
         this.querySelector('[data-webauthn-target="response"]').value = await this.stringifyAuthenticationCredentialWithGracefullyHandlingAuthenticatorIssues(credential);
 
-        this.closest('form').submit();
+        this.dataset.ceremonyCompleted = "true";
+        this.closest('form').requestSubmit();
       } catch (error) {
+        delete this.dataset.ceremonyCompleted;
         this.handleError(error);
       }
     });


### PR DESCRIPTION
## Motivation

Fixes #138.

## Details

- Replace `form.submit()` with `form.requestSubmit()` in both `<webauthn-create>` and `<webauthn-get>`. Unlike `submit()`, `requestSubmit()` dispatches a cancelable `submit` event, so Turbo (and any other `submit` listener) can
  intercept it.
- Guard against re-entry: since the components listen on the form's `submit` event, `requestSubmit()` would re-trigger their own handler. A `data-ceremony-completed` flag lets the second pass through to the browser/Turbo.