### PR TITLE
Fix errors installing `i18n` on Ruby 3.1 in the CI

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -14,6 +14,10 @@ end
 
 appraise "rails-7_2" do
   gem "rails", "~> 7.2.x"
+
+  install_if "-> { RUBY_VERSION >= \"3.1\" && RUBY_VERSION < \"3.2\" }" do
+    gem "i18n", "!= 1.15.0"
+  end
 end
 
 appraise "rails-7_1" do
@@ -25,6 +29,10 @@ appraise "rails-7_1" do
   gem "rack", "~> 2.2"
   gem "rspec-rails", "~> 7.1"
   gem "sqlite3", "~> 1.7"
+
+  install_if "-> { RUBY_VERSION >= \"3.1\" && RUBY_VERSION < \"3.2\" }" do
+    gem "i18n", "!= 1.15.0"
+  end
 end
 
 appraise "devise-5_0" do
@@ -39,4 +47,8 @@ appraise "devise-5_0" do
   end
   gem "rspec-rails", ">= 7.1"
   gem "sqlite3", ">= 1.6", "!= 1.7.0", "!= 1.7.1", "!= 1.7.2", "!= 1.7.3"
+
+  install_if "-> { RUBY_VERSION >= \"3.1\" && RUBY_VERSION < \"3.2\" }" do
+    gem "i18n", "!= 1.15.0"
+  end
 end

--- a/gemfiles/devise_5_0.gemfile
+++ b/gemfiles/devise_5_0.gemfile
@@ -23,4 +23,8 @@ install_if -> { RUBY_VERSION < "3.0" } do
   gem "rack", "~> 2.2"
 end
 
+install_if -> { RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" } do
+  gem "i18n", "!= 1.15.0"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -20,4 +20,8 @@ gem "selenium-webdriver"
 gem "sqlite3", "~> 1.7"
 gem "rack", "~> 2.2"
 
+install_if -> { RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" } do
+  gem "i18n", "!= 1.15.0"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -19,4 +19,8 @@ gem "rubocop-rspec", "~> 3.6"
 gem "selenium-webdriver"
 gem "sqlite3", "~> 2.7"
 
+install_if -> { RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" } do
+  gem "i18n", "!= 1.15.0"
+end
+
 gemspec path: "../"


### PR DESCRIPTION
## Motivation

Fixes #141.

## Details

This PR simply adds a constraint to our Appraisal generated gemfiles so that `i18n` `v1.15.0` is installed if Ruby is not `3.1`.